### PR TITLE
Permissive Timezone offset

### DIFF
--- a/object/commit.go
+++ b/object/commit.go
@@ -312,7 +312,7 @@ func consumeSignature(src []byte) (sig, tail []byte, _ error) {
 }
 
 func parseTZOffset(src []byte) (*time.Location, error) {
-	if len(src) != 5 {
+	if len(src) != 5 && len(src) != 4 {
 		return nil, fmt.Errorf("parse UTC offset %q: wrong length", src)
 	}
 	var sign int
@@ -324,13 +324,12 @@ func parseTZOffset(src []byte) (*time.Location, error) {
 	default:
 		return nil, fmt.Errorf("parse UTC offset %q: must start with plus or minus sign", src)
 	}
-	for _, b := range src[1:] {
-		if b < '0' || b > '9' {
-			return nil, fmt.Errorf("parse UTC offset %q: must have 4 digits after sign", src)
-		}
+	hhmm, err := strconv.Atoi(string(src[1:]))
+	if err != nil {
+		return nil, fmt.Errorf("parse UTC offset %q: %w", src, err)
 	}
-	hours := int(src[1]-'0')*10 + int(src[2]-'0')
-	minutes := int(src[3]-'0')*10 + int(src[4]-'0')
+	hours := hhmm / 100
+	minutes := hhmm % 100
 	offset := (hours*60*60 + minutes*60) * sign
 	return time.FixedZone(string(src), offset), nil
 }

--- a/object/tree.go
+++ b/object/tree.go
@@ -123,8 +123,18 @@ func (tree Tree) Len() int {
 }
 
 // Less reports whether the i'th entry name is less than the j'th entry name.
+// See git src comment regarding adding '/' to a dir object:
+//   https://github.com/git/git/blob/15030f9556f545b167b1879b877a5d780252dc16/fsck.c#L529-L536
 func (tree Tree) Less(i, j int) bool {
-	return tree[i].Name < tree[j].Name
+	lhs := tree[i].Name
+	rhs := tree[j].Name
+	if tree[i].Mode == ModeDir {
+		lhs += "/"
+	}
+	if tree[j].Mode == ModeDir {
+		rhs += "/"
+	}
+	return lhs < rhs 
 }
 
 // Swap swaps the i'th entry with the j'th entry.


### PR DESCRIPTION
(1) The current code in Tree's Less and Search is problematic. Git doesn't use alphabetic order when it sorts entries in a directory - it uses the so called "path order". The main difference is that if an entry is a subdir, a "/" character is appended during the sorting. This PR aims to fix that.

(2) The timezone offset change isn't technically a fix, but to make it permissive so that super old Git commit objects can be parsed. The current 5 character format in a Git object (+/-HHMM) is only standardized 9 years ago. If you try to parse a commit before that, the timezone offset part of the commit object may come in a different format. An example repo that can manifest this problem is https://github.com/vim-scripts/vim-addon-background-cmd and a couple other repos in vim-scripts. There, you can find very old commits that comes with a 4 character timezone offset, for example:
```
committer Able Scraper <scraper@vim-scripts.org> 1289713595 -800
```