### PR TITLE
Path order in Tree search and node compare

### DIFF
--- a/object/tree.go
+++ b/object/tree.go
@@ -123,8 +123,18 @@ func (tree Tree) Len() int {
 }
 
 // Less reports whether the i'th entry name is less than the j'th entry name.
+// See git src comment regarding adding '/' to a dir object:
+//   https://github.com/git/git/blob/15030f9556f545b167b1879b877a5d780252dc16/fsck.c#L529-L536
 func (tree Tree) Less(i, j int) bool {
-	return tree[i].Name < tree[j].Name
+	lhs := tree[i].Name
+	rhs := tree[j].Name
+	if tree[i].Mode == ModeDir {
+		lhs += "/"
+	}
+	if tree[j].Mode == ModeDir {
+		rhs += "/"
+	}
+	return lhs < rhs 
 }
 
 // Swap swaps the i'th entry with the j'th entry.


### PR DESCRIPTION
Split off the first part of https://github.com/gg-scm/gg-git/pull/32. 

Git doesn't use alphabetic order when it sorts entries in a directory - it uses the so called "path order". The main difference is that if an entry is a subdir, a "/" character is appended during the sorting. This PR aims to fix that. It does change a public API - tree.Search() now also takes a Mode param so that the search function can properly adding the trailing slash to it when necessary.

As discuss in the other PR, i also could not find any real doc on the path order. This is the comment in the Git source code where it mentions the subdir behavior:

https://github.com/git/git/blob/15030f9556f545b167b1879b877a5d780252dc16/fsck.c#L529-L536

Sorry I didn't add new tests for this. I wasn't sure what's the correct way of generating the testdata files. One type of Git repos that I think can easily reproduce the problem is anything that's created from Xcode, because it seems such projects always have the following directory structure:

```
myProject/
myProject.xcodeproj/
(... other stuff)
```
For example, https://github.com/orta/OROpenInAppCode